### PR TITLE
Fixes the Heading Quotes visibility in dark mode

### DIFF
--- a/data.json
+++ b/data.json
@@ -339,6 +339,21 @@
       "quote": "We can know only that we know nothing. And that is the highest degree of human wisdom.",
       "author": "Leo Tolstoy",
       "source": "War and Peace, 1869"
+    },
+    {
+      "quote": "In life Knowledge and Experience is more powerfull than Money.",
+      "author": "Ravichandra L S",
+      "source": "Self Experience" 
+    },
+    {
+      "quote": "The Talent without Hard-work is nothing.",
+      "author": "Ravichandra L S",
+      "source": "Self Experience" 
+    },
+    {
+      "quote": "Don't believe the person who acts as a foolish.",
+      "author": "Ravichandra L S",
+      "source": "Self Experience" 
     }  
   ]
 }

--- a/index.html
+++ b/index.html
@@ -23,24 +23,18 @@
   </head>
 
   <body class="merriweather-light">
-    <div
-      style="display: flex; justify-content: space-between; align-items: center"
-    >
+    <div class="header" style="display: flex; justify-content: space-between; align-items: center">
       <h2>Quotes.</h2>
       <div style="display: flex; align-items: center">
         <a
           href="https://github.com/JayShukla8/Quotes"
-          target="_blank"
-          class="github-link"
-        >
+          target="_blank"class="github-link">
           <svg
             height="32"
             width="32"
             viewBox="0 0 16 16"
             version="1.1"
-            aria-hidden="true"
-          >
-            <path
+            aria-hidden="true"><path
               fill="#000"
               fill-rule="evenodd"
               d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.59 7.59 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@ body {
 }
 
 .quote-block:hover {
-  box-shadow: 3px 3px  #797878;
+  box-shadow: 3px 3px #797878;
   zoom: 101%;
 }
 
@@ -73,6 +73,20 @@ body {
   vertical-align: middle;
 }
 
+.icons-container {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.icon {
+  cursor: pointer;
+  font-size: 1.2em;
+}
+
+/* Dark Mode Styles */
 body.dark {
   background-color: #333;
 }
@@ -87,24 +101,22 @@ body.dark .quote-text {
 }
 
 body.dark .quote-author,
-body.dark .quote-source {
+body.dark .quote-source,
+body.dark .heading-text {
+  color: #ddd;
+}
+
+body.dark h2 {
   color: #ddd;
 }
 
 
-body.dark .heading-text{
-    color: #ddd;
+.header {
+  background-color: rgb(220, 90, 90);
+  border-radius: 15px;
+  padding: 0px 20px; 
+  position: sticky;
+  top: 0; 
+  z-index: 1000; 
+  margin-bottom: 20px; 
 }
-
-.icons-container {
-  position: absolute;
-  right: 10px;
-  bottom: 10px;
-  display: flex;
-  gap: 10px;
-}
-.icon {
-  cursor: pointer;
-  font-size: 1.2em;
-}
-


### PR DESCRIPTION
 what does this PR do

Fixes #105 

* Fixed the problem of Heading Quotes visibility to white in dark mode.
* Added background for the header section.
* The header section is sticky and easily accessible to the header section.

**Before**

![image](https://github.com/user-attachments/assets/5edcf80c-0eec-4bca-bb9f-2b8318da7bf4)

**After**

https://github.com/user-attachments/assets/22b20b5a-c882-456d-ac7e-12468c1215df

@JayShukla8 Review My Commit and Accept
