### PR TITLE
feature/quote-to-image-maker

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
   <script src="bubble.js"></script>
   <script src="script.js"></script>
   <script src="mode.js"></script>
+  <script src="quoteImage.js"></script>
 </body>
 
 </html>

--- a/quoteImage.js
+++ b/quoteImage.js
@@ -1,0 +1,59 @@
+function saveQuoteAsImage(quoteElement) {
+    const quoteText = quoteElement.querySelector('.quote-text').textContent;
+    const authorText = quoteElement.querySelector('.quote-author').textContent;
+    const sourceText = quoteElement.querySelector('.quote-source').textContent;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 600;
+    canvas.height = 400;
+    const ctx = canvas.getContext('2d');
+
+    const gradient = ctx.createLinearGradient(0, 0, 600, 400);
+    gradient.addColorStop(0, document.body.classList.contains('dark') ? '#1a1a4b' : '#ffe6e6');
+    gradient.addColorStop(1, document.body.classList.contains('dark') ? '#4b0082' : '#e6f7ff');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.font = '24px "Merriweather", serif';
+    ctx.fillStyle = document.body.classList.contains('dark') ? '#e3cdb3' : '#333';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    const lines = wrapText(ctx, quoteText, canvas.width * 0.8);
+
+    lines.forEach((line, index) => {
+        ctx.fillText(line, canvas.width / 2, (canvas.height / 2) - ((lines.length - 1) * 15) + (index * 30));
+    });
+
+    ctx.font = 'italic 18px "Merriweather", serif';
+    ctx.fillText(authorText, canvas.width / 2, canvas.height - 80);
+
+    // Draw source
+    ctx.font = '14px "Merriweather", serif';
+    ctx.fillText(sourceText, canvas.width / 2, canvas.height - 50);
+
+    const image = canvas.toDataURL("image/png");
+    const link = document.createElement('a');
+    link.href = image;
+    link.download = 'quote.png';
+    link.click();
+}
+
+function wrapText(context, text, maxWidth) {
+    const words = text.split(' ');
+    const lines = [];
+    let currentLine = words[0];
+
+    for (let i = 1; i < words.length; i++) {
+        const word = words[i];
+        const width = context.measureText(currentLine + " " + word).width;
+        if (width < maxWidth) {
+            currentLine += " " + word;
+        } else {
+            lines.push(currentLine);
+            currentLine = word;
+        }
+    }
+    lines.push(currentLine);
+    return lines;
+}

--- a/script.js
+++ b/script.js
@@ -85,6 +85,7 @@ document.addEventListener("DOMContentLoaded", function () {
         iconsWrapper.appendChild(copyIcon);
         iconsWrapper.appendChild(shareIcon);
         iconsWrapper.appendChild(voiceIcon);
+        iconsWrapper.appendChild(saveImageIcon);
         iconsContainer.appendChild(iconsWrapper);
 
         // Append like icon and source text to card bottom

--- a/script.js
+++ b/script.js
@@ -53,6 +53,9 @@ document.addEventListener("DOMContentLoaded", function () {
         const likeIcon = document.createElement("i");
         likeIcon.className = "icon fas fa-heart"; 
 
+        const saveImageIcon = document.createElement("i");
+        saveImageIcon.className = "icon fas fa-image";
+        saveImageIcon.title = "Save as Image";
         
         if (likedQuotes.includes(quoteText.textContent)) {
           likeIcon.classList.add("liked"); 
@@ -63,6 +66,7 @@ document.addEventListener("DOMContentLoaded", function () {
         iconsContainer.appendChild(shareIcon);
         iconsContainer.appendChild(voiceIcon);
         iconsContainer.appendChild(likeIcon); 
+        iconsContainer.appendChild(saveImageIcon); 
 
         // Append elements to the quote block
         quoteBlock.appendChild(quoteText);
@@ -124,6 +128,10 @@ document.addEventListener("DOMContentLoaded", function () {
             likedQuotes.push(quoteText.textContent);
           }
           localStorage.setItem("likedQuotes", JSON.stringify(likedQuotes));
+        });
+
+        saveImageIcon.addEventListener("click", function () {
+          saveQuoteAsImage(quoteBlock);
         });
       });
     })


### PR DESCRIPTION
# Add 'Save as Image' Feature

## Summary
This PR allows users to save quotes as images, matching the website's theme and background.

## Features
- New 'Save as Image' icon for each quote
- Generated images adapt to light/dark mode

## Implementation
- New `quoteImage.js` for image generation logic
- Updated `script.js` to integrate new functionality
- Uses HTML5 Canvas API for high-quality output

## Screenshots
**Image button added.**
![webpage](https://github.com/user-attachments/assets/940e1bcc-3099-45e1-b2d4-1dc2d907ae13)
**Light Mode image.**
![lightmode](https://github.com/user-attachments/assets/e18b363c-0f4a-4285-9ef9-f51e9a5a23c2)
**Dark Mode Image.**
![darkmode](https://github.com/user-attachments/assets/41172007-167d-42ab-b5af-3a7447449091)
