### PR TITLE
Add inline link to CONTRIBUTING to improve accessibility in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Some of the greatest quotes, submitted by You.[^1]
 [here](https://jayshukla8.github.io/Quotes/)
 
 ## Contributing
-Please check CONTRIBUTING.md for how?
+Please check [CONTRIBUTING.md](https://github.com/JayShukla8/Quotes/blob/main/CONTRIBUTING.md) for how?
 
 For newbies, adding your favorite quote (From any source that you like along with the author and the source.) in the data.json file would be a good-first-issue. 
 


### PR DESCRIPTION
Fixes https://github.com/JayShukla8/Quotes/issues/185.


The link to [CONTRIBUTING.md](https://github.com/JayShukla8/Quotes/blob/main/CONTRIBUTING.md) in  [README](https://github.com/JayShukla8/Quotes/blob/main/README.md) file currently is just a plain text. 

https://github.com/JayShukla8/Quotes/blob/cf7da08769d1160cfbb57ec8074e2c42f3c7b738/README.md?plain=1#L7

- [x] Added an inline link for the same will improve accessibility.

Contributing as a registered participant of `Hacktoberfest`. Do let me know for any changes or improvements.